### PR TITLE
auto input filename include  boot9.bin,seeddb.bin,movable.sed 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ venv/
 =======
 
 *.pyc
+/build/
+/dist/
+/custom-install-finalize.3dsx

--- a/ci-gui.py
+++ b/ci-gui.py
@@ -329,7 +329,7 @@ class CustomInstallGUI(ttk.Frame):
         def auto_input_filename(self, f, filename):
             sd_msed_path = find_first_file([join(f, 'gm9', 'out', filename), join(f, filename)])
             if sd_msed_path:
-                self.log('Found movable.sed on SD card at ' + sd_msed_path)
+                self.log('Found ' + filename + ' on SD card at ' + sd_msed_path)
                 if filename.endswith('bin'):
                     filename = filename.split('.')[0]
                 box = self.file_picker_textboxes[filename]

--- a/ci-gui.py
+++ b/ci-gui.py
@@ -306,12 +306,9 @@ class CustomInstallGUI(ttk.Frame):
                 sd_selected.delete('1.0', tk.END)
                 sd_selected.insert(tk.END, f)
 
-                sd_msed_path = find_first_file([join(f, 'gm9', 'out', 'movable.sed'), join(f, 'movable.sed')])
-                if sd_msed_path:
-                    self.log('Found movable.sed on SD card at ' + sd_msed_path)
-                    box = self.file_picker_textboxes['movable.sed']
-                    box.delete('1.0', tk.END)
-                    box.insert(tk.END, sd_msed_path)
+                for filename in ['boot9.bin', 'seeddb.bin', 'movable.sed']:
+                    auto_input_filename(self, f, filename)
+
 
         sd_type_label = ttk.Label(file_pickers, text='SD root')
         sd_type_label.grid(row=0, column=0)
@@ -324,6 +321,15 @@ class CustomInstallGUI(ttk.Frame):
 
         self.file_picker_textboxes['sd'] = sd_selected
 
+        def auto_input_filename(self, f, filename):
+            sd_msed_path = find_first_file([join(f, 'gm9', 'out', filename), join(f, filename)])
+            if sd_msed_path:
+                self.log('Found movable.sed on SD card at ' + sd_msed_path)
+                if filename.endswith('bin'):
+                    filename = filename.split('.')[0]
+                box = self.file_picker_textboxes[filename]
+                box.delete('1.0', tk.END)
+                box.insert(tk.END, sd_msed_path)
         # This feels so wrong.
         def create_required_file_picker(type_name, types, default, row, callback=lambda filename: None):
             def internal_callback():

--- a/ci-gui.py
+++ b/ci-gui.py
@@ -307,7 +307,12 @@ class CustomInstallGUI(ttk.Frame):
                 sd_selected.insert(tk.END, f)
 
                 for filename in ['boot9.bin', 'seeddb.bin', 'movable.sed']:
-                    auto_input_filename(self, f, filename)
+                    path = auto_input_filename(self, f, filename)
+                    if filename == 'boot9.bin':
+                        self.check_b9_loaded()
+                        self.enable_buttons()
+                    if filename == 'seeddb.bin':
+                        load_seeddb(path)
 
 
         sd_type_label = ttk.Label(file_pickers, text='SD root')
@@ -330,6 +335,7 @@ class CustomInstallGUI(ttk.Frame):
                 box = self.file_picker_textboxes[filename]
                 box.delete('1.0', tk.END)
                 box.insert(tk.END, sd_msed_path)
+                return sd_msed_path
         # This feels so wrong.
         def create_required_file_picker(type_name, types, default, row, callback=lambda filename: None):
             def internal_callback():


### PR DESCRIPTION
auto input filename include  `boot9.bin` , `seeddb.bin` and `movable.sed`  when they are in <sd>:/gm9/out