### PR TITLE
Update cflags in Makefile of finalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .vscode/
 bin/linux/save3ds_fuse
-**/finalize
 cstins/
 testing-class.py
 

--- a/finalize/Makefile
+++ b/finalize/Makefile
@@ -54,7 +54,7 @@ CFLAGS	:=	-g -Wall -O2 -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS
+CFLAGS	+=	$(INCLUDE) -D__3DS__
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 


### PR DESCRIPTION
3ds.h currently prints a Warning when it detects the usage of compilation flags -DARM11 -D_3DS, stating that -D__3DS__ should be used in their stead.

See https://github.com/devkitPro/libctru/commit/48967dc417deca60592e4137084f74a27411913f