### PR TITLE
add: add boot9strap dir for searching autoinput file

### DIFF
--- a/ci-gui.py
+++ b/ci-gui.py
@@ -335,7 +335,9 @@ class CustomInstallGUI(ttk.Frame):
         self.file_picker_textboxes['sd'] = sd_selected
 
         def auto_input_filename(self, f, filename):
-            sd_msed_path = find_first_file([join(f, 'gm9', 'out', filename), join(f, filename)])
+            sd_msed_path = find_first_file(
+                [join(f, "gm9", "out", filename), join(f, "boot9strap", filename), join(f, filename)]
+            )
             if sd_msed_path:
                 self.log('Found ' + filename + ' on SD card at ' + sd_msed_path)
                 if filename.endswith('bin'):


### PR DESCRIPTION
According to [Dumping ... FIles](https://ihaveamac.github.io/dump.html) Guide, when we use installing boot9strap with `ntrboot`, they automaticallyt backup `boot9.bin` into `/boot9strap`.

So I add the directory for automatically search it 